### PR TITLE
add userRole to responses, per-game editor access control

### DIFF
--- a/config/auth.js
+++ b/config/auth.js
@@ -1,3 +1,19 @@
+import { prisma } from "../lib/prisma.js";
+
+export async function isEditorForGame(userId, gameId) {
+    if (!gameId) return false;
+    const entry = await prisma.gameEditor.findUnique({
+        where: { userId_gameId: { userId, gameId } },
+    });
+    return !!entry;
+}
+
+export function canEditGame(user, gameId) {
+    if (!user) return Promise.resolve(false);
+    if (user.role === "ADMIN" || user.role === "EDITOR") return Promise.resolve(true);
+    return isEditorForGame(user.id, gameId);
+}
+
 export function requireAuth(req, res, next) {
     if (req.isAuthenticated()) {
         next();

--- a/controllers/blocksController.js
+++ b/controllers/blocksController.js
@@ -2,6 +2,7 @@ import db from "../db/blocksQueries.js";
 import pendingDb from "../db/pendingQueries.js";
 import pagesDb from "../db/pagesQueries.js";
 import contributionDb from "../db/contributionQueries.js";
+import { canEditGame } from "../config/auth.js";
 
 async function getBlock(req, res) {
     const blockId = +req.params.blockId;
@@ -22,7 +23,7 @@ async function deleteBlock(req, res) {
 
     console.log("Block deletion request received on block ID:" + id);
 
-    if (req.user.role === "ADMIN" || req.user.role === "EDITOR") {
+    if (await canEditGame(req.user, gameId)) {
         const result = await db.deleteBlock({ id, gameId });
         console.log("Deleted block:");
         console.log(result);
@@ -54,7 +55,7 @@ async function updateBlock(req, res) {
     console.log("Block update request received for Block ID: " + id);
     const { content, content2, type } = req.body;
 
-    if (req.user.role === "ADMIN" || req.user.role === "EDITOR") {
+    if (await canEditGame(req.user, gameId)) {
         const result = await db.updateBlock({ id, content, content2, gameId });
         console.log(result);
         await pagesDb.addContributor({ pageId: result.pageId, userId: req.user.id });

--- a/controllers/pagesController.js
+++ b/controllers/pagesController.js
@@ -1,5 +1,6 @@
 import db from "../db/pagesQueries.js";
 import pendingDb from "../db/pendingQueries.js";
+import { canEditGame } from "../config/auth.js";
 
 async function getPages(req, res) {
     const gameId = +req.params.gameId;
@@ -130,15 +131,12 @@ async function getPage(req, res) {
 async function createBlockForPage(req, res) {
     console.log("Received block creation request");
     const pageId = +req.params.pageId;
+    const gameId = req.params.gameId ? +req.params.gameId : null;
     const order = +req.body.order;
     const type = req.body.type;
-    // blank type implies it's a text block
-    //const result = await db.createBlockForPage({ pageId, order, type });
-    //console.log(result);
-    //res.send(result);
-    //const content = req.body.content;
+    const content = req.body.content;
 
-    if (req.user.role === "ADMIN" || req.user.role === "EDITOR") {
+    if (await canEditGame(req.user, gameId)) {
         const result = await db.createBlockForPage({ pageId, order, type });
         console.log(result);
         res.send(result);
@@ -157,11 +155,12 @@ async function createBlockForPage(req, res) {
 
 async function updateBlocksForPage(req, res) {
     const pageId = +req.params.pageId;
+    const gameId = req.params.gameId ? +req.params.gameId : null;
     const updateType = req.body.type;
     const order = +req.body.order;
     console.log("Received request to update blocks for page " + pageId);
     console.log(updateType);
-    if (req.user.role === "ADMIN" || req.user.role === "EDITOR") {
+    if (await canEditGame(req.user, gameId)) {
         let result;
         if (updateType === "offset") {
             result = await offsetBlockOrderForPage(pageId, order);

--- a/controllers/sectionsController.js
+++ b/controllers/sectionsController.js
@@ -3,9 +3,11 @@ import createSectionRecord, {
     renameSectionRecord,
     updateSectionOrder,
     // getAllSectionsByGame,
-    // above fn  was unused but i created a query in sectionsQueries.js for it, cant remember why. but nothing breaks so far i think 
-    changePageSectionRecord
+    // above fn  was unused but i created a query in sectionsQueries.js for it, cant remember why. but nothing breaks so far i think
+    changePageSectionRecord,
+    getGameWithSectionId,
 } from "../db/sectionsQueries.js";
+import { canEditGame } from "../config/auth.js";
 
 export default async function createSection(req, res) {
     const { title, gameId, order } = req.body;
@@ -14,6 +16,8 @@ export default async function createSection(req, res) {
     if (!title || !gameId) {
         return res.status(400).send({ error: "Title and gameId are required" });
     }
+
+    if (!(await canEditGame(req.user, +gameId))) return res.sendStatus(403);
 
     try {
         const result = await createSectionRecord(title, gameId, order);
@@ -28,16 +32,22 @@ export async function changePageSection(req, res) {
     const sectionId = req.body.sectionId;
     const pageId = +req.params.id;
 
-    console.log(sectionId, pageId, ": sectionId and pageId");
+    const section = sectionId ? await getGameWithSectionId(sectionId) : null;
+    const gameId = section?.gameId ?? null;
+    if (!(await canEditGame(req.user, gameId))) return res.sendStatus(403);
 
+    console.log(sectionId, pageId, ": sectionId and pageId");
     const result = await changePageSectionRecord({ pageId, sectionId });
     res.send(result);
 }
 
-
 export async function deleteSection(req, res) {
     const sectionId = Number(req.params.id);
     console.log(sectionId, "is the ID to be deleted");
+
+    const section = await getGameWithSectionId(sectionId);
+    if (!(await canEditGame(req.user, section?.gameId ?? null))) return res.sendStatus(403);
+
     try {
         const result = await deleteSectionRecord(sectionId);
         res.status(201).send(result);
@@ -50,6 +60,10 @@ export async function deleteSection(req, res) {
 export async function renameSection(req, res) {
     const sectionId = Number(req.params.id);
     const title = req.body.title;
+
+    const section = await getGameWithSectionId(sectionId);
+    if (!(await canEditGame(req.user, section?.gameId ?? null))) return res.sendStatus(403);
+
     try {
         const result = await renameSectionRecord(sectionId, title);
         res.status(201).send(result);
@@ -69,8 +83,9 @@ export async function reorderSection(req, res) {
             });
         }
 
-        await updateSectionOrder(sectionOrder, gameId);
+        if (!(await canEditGame(req.user, +gameId))) return res.sendStatus(403);
 
+        await updateSectionOrder(sectionOrder, gameId);
         res.json({ success: true });
     } catch (error) {
         console.error("Failed to reorder sections:", error);

--- a/db/chatQueries.js
+++ b/db/chatQueries.js
@@ -1,19 +1,22 @@
 import { prisma } from "../lib/prisma.js";
 
 async function getChatMessages(gameId, limit = 100) {
-    return prisma.chatMessage.findMany({
+    const messages = await prisma.chatMessage.findMany({
         where: { gameId },
         orderBy: { createdAt: "asc" },
         take: limit,
-        select: { id: true, userId: true, username: true, text: true, type: true, createdAt: true },
+        select: { id: true, userId: true, username: true, text: true, type: true, createdAt: true, user: { select: { role: true } } },
     });
+    return messages.map(({ user, ...m }) => ({ ...m, userRole: user.role }));
 }
 
 async function createChatMessage({ gameId, userId, username, text, type = "message" }) {
-    return prisma.chatMessage.create({
+    const message = await prisma.chatMessage.create({
         data: { gameId, userId, username, text, type },
-        select: { id: true, userId: true, username: true, text: true, type: true, createdAt: true },
+        select: { id: true, userId: true, username: true, text: true, type: true, createdAt: true, user: { select: { role: true } } },
     });
+    const { user, ...rest } = message;
+    return { ...rest, userRole: user.role };
 }
 
 async function getChatMessage(id) {

--- a/db/commentQueries.js
+++ b/db/commentQueries.js
@@ -15,9 +15,10 @@ async function resolvePageId(pageIdParam) {
 }
 
 function formatComment(comment, currentUserId) {
-    const { upvotes, replies, ...rest } = comment;
+    const { upvotes, replies, user, ...rest } = comment;
     return {
         ...rest,
+        userRole: user?.role ?? "USER",
         upvoteCount: upvotes ? upvotes.length : 0,
         hasUpvoted: currentUserId
             ? upvotes.some((u) => u.userId === currentUserId)
@@ -37,11 +38,13 @@ async function getAllCommentsForGame(gameId, currentUserId) {
         orderBy: { createdAt: "desc" },
         include: {
             page: { select: { title: true, slug: true } },
+            user: { select: { role: true } },
             upvotes: { select: { userId: true } },
             replies: {
                 orderBy: { createdAt: "asc" },
                 include: {
                     page: { select: { title: true, slug: true } },
+                    user: { select: { role: true } },
                     upvotes: { select: { userId: true } },
                 },
             },
@@ -49,17 +52,19 @@ async function getAllCommentsForGame(gameId, currentUserId) {
     });
 
     return comments.map((c) => {
-        const { page, upvotes, replies, ...rest } = c;
+        const { page, user, upvotes, replies, ...rest } = c;
         return {
             ...rest,
+            userRole: user.role,
             pageTitle: page.title,
             pageSlug: page.slug,
             upvoteCount: upvotes.length,
             hasUpvoted: currentUserId ? upvotes.some((u) => u.userId === currentUserId) : false,
             replies: replies.map((r) => {
-                const { page: rPage, upvotes: rUpvotes, ...rRest } = r;
+                const { page: rPage, user: rUser, upvotes: rUpvotes, ...rRest } = r;
                 return {
                     ...rRest,
+                    userRole: rUser.role,
                     pageTitle: rPage.title,
                     pageSlug: rPage.slug,
                     upvoteCount: rUpvotes.length,
@@ -75,10 +80,12 @@ async function getCommentsForPage(pageId, currentUserId) {
         where: { pageId, parentId: null },
         orderBy: { createdAt: "asc" },
         include: {
+            user: { select: { role: true } },
             upvotes: { select: { userId: true } },
             replies: {
                 orderBy: { createdAt: "asc" },
                 include: {
+                    user: { select: { role: true } },
                     upvotes: { select: { userId: true } },
                 },
             },
@@ -90,7 +97,7 @@ async function getCommentsForPage(pageId, currentUserId) {
 async function createComment({ pageId, userId, username, text }) {
     const comment = await prisma.comment.create({
         data: { pageId, userId, username, text },
-        include: { upvotes: { select: { userId: true } } },
+        include: { user: { select: { role: true } }, upvotes: { select: { userId: true } } },
     });
     return formatComment({ ...comment, replies: [] }, userId);
 }
@@ -106,7 +113,7 @@ async function createReply({ parentId, userId, username, text }) {
 
     const reply = await prisma.comment.create({
         data: { pageId: parent.pageId, userId, username, text, parentId },
-        include: { upvotes: { select: { userId: true } } },
+        include: { user: { select: { role: true } }, upvotes: { select: { userId: true } } },
     });
     return formatComment(reply, userId);
 }
@@ -120,10 +127,11 @@ async function updateComment(id, text) {
         where: { id },
         data: { text },
         include: {
+            user: { select: { role: true } },
             upvotes: { select: { userId: true } },
             replies: {
                 orderBy: { createdAt: "asc" },
-                include: { upvotes: { select: { userId: true } } },
+                include: { user: { select: { role: true } }, upvotes: { select: { userId: true } } },
             },
         },
     });

--- a/routes/sectionsRouter.js
+++ b/routes/sectionsRouter.js
@@ -1,4 +1,4 @@
-import { requireEditor } from "../config/auth.js";
+import { requireAuth } from "../config/auth.js";
 import createSection, {
     renameSection,
     reorderSection,
@@ -10,10 +10,10 @@ import { Router } from "express";
 const router = Router();
 
 // route is /sections
-router.post("/", requireEditor, createSection);
-router.delete("/delete/:id", requireEditor, deleteSection);
-router.put("/rename/:id", requireEditor, renameSection);
-router.put("/reorder", requireEditor, reorderSection);
+router.post("/", requireAuth, createSection);
+router.delete("/delete/:id", requireAuth, deleteSection);
+router.put("/rename/:id", requireAuth, renameSection);
+router.put("/reorder", requireAuth, reorderSection);
 router.get("/navbar", getNavbar);
-router.put("/:id", requireEditor, changePageSection);
+router.put("/:id", requireAuth, changePageSection);
 export default router;

--- a/tests/editorAccess.test.js
+++ b/tests/editorAccess.test.js
@@ -1,0 +1,381 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import express from "express";
+import request from "supertest";
+
+// prisma mock — findUnique controlled per-test via vi.mocked(prisma.gameEditor.findUnique)
+vi.mock("../lib/prisma.js", () => ({
+    prisma: {
+        gameEditor: {
+            findUnique: vi.fn(),
+        },
+    },
+}));
+
+vi.mock("../db/blocksQueries.js", () => ({
+    default: {
+        getBlock: vi.fn(),
+        updateBlock: vi.fn(),
+        deleteBlock: vi.fn(),
+    },
+}));
+
+vi.mock("../db/pendingQueries.js", () => ({
+    default: {
+        findPendingBlockByBlockIdAndOperation: vi.fn(),
+        createPendingBlock: vi.fn(),
+        updatePendingBlock: vi.fn(),
+    },
+}));
+
+vi.mock("../db/pagesQueries.js", () => ({
+    default: {
+        addContributor: vi.fn(),
+        createBlockForPage: vi.fn(),
+        offsetBlockOrderForPage: vi.fn(),
+    },
+}));
+
+vi.mock("../db/contributionQueries.js", () => ({
+    default: { createContribution: vi.fn() },
+}));
+
+vi.mock("../db/sectionsQueries.js", () => ({
+    default: vi.fn(),
+    deleteSectionRecord: vi.fn(),
+    renameSectionRecord: vi.fn(),
+    updateSectionOrder: vi.fn(),
+    changePageSectionRecord: vi.fn(),
+    getGameWithSectionId: vi.fn(),
+}));
+
+import { prisma } from "../lib/prisma.js";
+import blocksDb from "../db/blocksQueries.js";
+import pendingDb from "../db/pendingQueries.js";
+import pagesDb from "../db/pagesQueries.js";
+import createSectionRecord, {
+    deleteSectionRecord,
+    renameSectionRecord,
+    updateSectionOrder,
+    changePageSectionRecord,
+    getGameWithSectionId,
+} from "../db/sectionsQueries.js";
+import blocksController from "../controllers/blocksController.js";
+import pagesController from "../controllers/pagesController.js";
+import createSection, {
+    deleteSection,
+    renameSection,
+    reorderSection,
+    changePageSection,
+} from "../controllers/sectionsController.js";
+
+function buildApp(user) {
+    const app = express();
+    app.use(express.json());
+    app.use((req, _res, next) => { req.user = user; next(); });
+
+    // blocks routes
+    const blocksRouter = express.Router({ mergeParams: true });
+    blocksRouter.put("/:blockId", blocksController.updateBlock);
+    blocksRouter.delete("/:blockId", blocksController.deleteBlock);
+    app.use("/games/:gameId/blocks", blocksRouter);
+
+    // page block routes
+    const pagesRouter = express.Router({ mergeParams: true });
+    pagesRouter.post("/by-id/:pageId/blocks", pagesController.createBlockForPage);
+    pagesRouter.put("/by-id/:pageId/blocks", pagesController.updateBlocksForPage);
+    app.use("/games/:gameId/pages", pagesRouter);
+
+    // sections routes
+    app.post("/sections", createSection);
+    app.delete("/sections/:id", deleteSection);
+    app.put("/sections/rename/:id", renameSection);
+    app.put("/sections/reorder", reorderSection);
+    app.put("/sections/:id", changePageSection);
+
+    return app;
+}
+
+const ADMIN   = { id: 1, username: "admin",   role: "ADMIN" };
+const EDITOR  = { id: 2, username: "editor",  role: "EDITOR" };
+const GAME_ED = { id: 3, username: "gameditor", role: "USER" };
+const USER    = { id: 4, username: "user",    role: "USER" };
+
+const findUnique = () => vi.mocked(prisma.gameEditor.findUnique);
+
+beforeEach(() => {
+    vi.clearAllMocks();
+    findUnique().mockResolvedValue(null);
+});
+
+function makeGameEditor(userId, gameId) {
+    findUnique().mockImplementation(({ where }) => {
+        if (where.userId_gameId.userId === userId && where.userId_gameId.gameId === gameId) {
+            return Promise.resolve({ userId, gameId });
+        }
+        return Promise.resolve(null);
+    });
+}
+
+// ─── BLOCK UPDATE ────────────────────────────────────────────────────────────
+
+describe("PUT /games/:gameId/blocks/:blockId (updateBlock)", () => {
+    beforeEach(() => {
+        blocksDb.getBlock.mockResolvedValue({ id: 1, pageId: 10 });
+        blocksDb.updateBlock.mockResolvedValue({ id: 1, pageId: 10 });
+        pagesDb.addContributor.mockResolvedValue({});
+    });
+
+    it("admin gets direct update (200)", async () => {
+        const res = await request(buildApp(ADMIN))
+            .put("/games/1/blocks/1")
+            .send({ content: {}, type: "text" });
+        expect(res.status).toBe(200);
+        expect(blocksDb.updateBlock).toHaveBeenCalled();
+        expect(pendingDb.createPendingBlock).not.toHaveBeenCalled();
+    });
+
+    it("global editor gets direct update (200)", async () => {
+        const res = await request(buildApp(EDITOR))
+            .put("/games/1/blocks/1")
+            .send({ content: {}, type: "text" });
+        expect(res.status).toBe(200);
+        expect(blocksDb.updateBlock).toHaveBeenCalled();
+    });
+
+    it("per-game editor gets direct update (200)", async () => {
+        makeGameEditor(GAME_ED.id, 1);
+        const res = await request(buildApp(GAME_ED))
+            .put("/games/1/blocks/1")
+            .send({ content: {}, type: "text" });
+        expect(res.status).toBe(200);
+        expect(blocksDb.updateBlock).toHaveBeenCalled();
+        expect(pendingDb.createPendingBlock).not.toHaveBeenCalled();
+    });
+
+    it("per-game editor for WRONG game goes to pending (202)", async () => {
+        makeGameEditor(GAME_ED.id, 99); // editor for game 99, not game 1
+        pendingDb.findPendingBlockByBlockIdAndOperation.mockResolvedValue(null);
+        const res = await request(buildApp(GAME_ED))
+            .put("/games/1/blocks/1")
+            .send({ content: {}, type: "text" });
+        expect(res.status).toBe(202);
+        expect(pendingDb.createPendingBlock).toHaveBeenCalled();
+    });
+
+    it("regular user goes to pending (202)", async () => {
+        pendingDb.findPendingBlockByBlockIdAndOperation.mockResolvedValue(null);
+        const res = await request(buildApp(USER))
+            .put("/games/1/blocks/1")
+            .send({ content: {}, type: "text" });
+        expect(res.status).toBe(202);
+        expect(blocksDb.updateBlock).not.toHaveBeenCalled();
+        expect(pendingDb.createPendingBlock).toHaveBeenCalled();
+    });
+});
+
+// ─── BLOCK DELETE ────────────────────────────────────────────────────────────
+
+describe("DELETE /games/:gameId/blocks/:blockId (deleteBlock)", () => {
+    beforeEach(() => {
+        blocksDb.getBlock.mockResolvedValue({ id: 1 });
+        blocksDb.deleteBlock.mockResolvedValue({ id: 1 });
+    });
+
+    it("admin deletes directly (200)", async () => {
+        const res = await request(buildApp(ADMIN)).delete("/games/1/blocks/1");
+        expect(res.status).toBe(200);
+        expect(blocksDb.deleteBlock).toHaveBeenCalled();
+    });
+
+    it("global editor deletes directly (200)", async () => {
+        const res = await request(buildApp(EDITOR)).delete("/games/1/blocks/1");
+        expect(res.status).toBe(200);
+    });
+
+    it("per-game editor deletes directly (200)", async () => {
+        makeGameEditor(GAME_ED.id, 1);
+        const res = await request(buildApp(GAME_ED)).delete("/games/1/blocks/1");
+        expect(res.status).toBe(200);
+        expect(blocksDb.deleteBlock).toHaveBeenCalled();
+    });
+
+    it("per-game editor for wrong game goes to pending (202)", async () => {
+        makeGameEditor(GAME_ED.id, 99);
+        pendingDb.findPendingBlockByBlockIdAndOperation.mockResolvedValue(null);
+        const res = await request(buildApp(GAME_ED)).delete("/games/1/blocks/1");
+        expect(res.status).toBe(202);
+    });
+
+    it("regular user goes to pending (202)", async () => {
+        pendingDb.findPendingBlockByBlockIdAndOperation.mockResolvedValue(null);
+        const res = await request(buildApp(USER)).delete("/games/1/blocks/1");
+        expect(res.status).toBe(202);
+        expect(blocksDb.deleteBlock).not.toHaveBeenCalled();
+    });
+
+    it("returns 404 if block not found", async () => {
+        blocksDb.getBlock.mockResolvedValue(null);
+        const res = await request(buildApp(ADMIN)).delete("/games/1/blocks/999");
+        expect(res.status).toBe(404);
+    });
+});
+
+// ─── PAGE BLOCKS ─────────────────────────────────────────────────────────────
+
+describe("POST /games/:gameId/pages/by-id/:pageId/blocks (createBlockForPage)", () => {
+    beforeEach(() => {
+        pagesDb.createBlockForPage.mockResolvedValue({ id: 5, pageId: 10 });
+    });
+
+    it("admin creates directly", async () => {
+        const res = await request(buildApp(ADMIN))
+            .post("/games/1/pages/by-id/10/blocks")
+            .send({ order: 0, type: "text" });
+        expect(res.status).toBe(200);
+        expect(pagesDb.createBlockForPage).toHaveBeenCalled();
+    });
+
+    it("global editor creates directly", async () => {
+        const res = await request(buildApp(EDITOR))
+            .post("/games/1/pages/by-id/10/blocks")
+            .send({ order: 0, type: "text" });
+        expect(res.status).toBe(200);
+    });
+
+    it("per-game editor creates directly", async () => {
+        makeGameEditor(GAME_ED.id, 1);
+        const res = await request(buildApp(GAME_ED))
+            .post("/games/1/pages/by-id/10/blocks")
+            .send({ order: 0, type: "text" });
+        expect(res.status).toBe(200);
+        expect(pagesDb.createBlockForPage).toHaveBeenCalled();
+    });
+
+    it("per-game editor for wrong game goes to pending (202)", async () => {
+        makeGameEditor(GAME_ED.id, 99);
+        pendingDb.createPendingBlock.mockResolvedValue({});
+        const res = await request(buildApp(GAME_ED))
+            .post("/games/1/pages/by-id/10/blocks")
+            .send({ order: 0, type: "text" });
+        expect(res.status).toBe(202);
+        expect(pagesDb.createBlockForPage).not.toHaveBeenCalled();
+    });
+
+    it("regular user goes to pending (202)", async () => {
+        pendingDb.createPendingBlock.mockResolvedValue({});
+        const res = await request(buildApp(USER))
+            .post("/games/1/pages/by-id/10/blocks")
+            .send({ order: 0, type: "text" });
+        expect(res.status).toBe(202);
+    });
+});
+
+// ─── SECTIONS ────────────────────────────────────────────────────────────────
+
+describe("Sections — access control", () => {
+    beforeEach(() => {
+        createSectionRecord.mockResolvedValue({ id: 1 });
+        deleteSectionRecord.mockResolvedValue({ id: 1 });
+        renameSectionRecord.mockResolvedValue({ id: 1 });
+        updateSectionOrder.mockResolvedValue({});
+        changePageSectionRecord.mockResolvedValue({ id: 1 });
+        getGameWithSectionId.mockResolvedValue({ gameId: 1 });
+    });
+
+    it("admin can create section", async () => {
+        const res = await request(buildApp(ADMIN))
+            .post("/sections")
+            .send({ title: "New", gameId: 1 });
+        expect(res.status).toBe(201);
+    });
+
+    it("global editor can create section", async () => {
+        const res = await request(buildApp(EDITOR))
+            .post("/sections")
+            .send({ title: "New", gameId: 1 });
+        expect(res.status).toBe(201);
+    });
+
+    it("per-game editor can create section for their game", async () => {
+        makeGameEditor(GAME_ED.id, 1);
+        const res = await request(buildApp(GAME_ED))
+            .post("/sections")
+            .send({ title: "New", gameId: 1 });
+        expect(res.status).toBe(201);
+    });
+
+    it("per-game editor blocked from another game's section", async () => {
+        makeGameEditor(GAME_ED.id, 99);
+        const res = await request(buildApp(GAME_ED))
+            .post("/sections")
+            .send({ title: "New", gameId: 1 });
+        expect(res.status).toBe(403);
+    });
+
+    it("regular user blocked from creating section (403)", async () => {
+        const res = await request(buildApp(USER))
+            .post("/sections")
+            .send({ title: "New", gameId: 1 });
+        expect(res.status).toBe(403);
+    });
+
+    it("admin can delete section", async () => {
+        const res = await request(buildApp(ADMIN)).delete("/sections/1");
+        expect(res.status).toBe(201);
+    });
+
+    it("per-game editor can delete section for their game", async () => {
+        makeGameEditor(GAME_ED.id, 1);
+        const res = await request(buildApp(GAME_ED)).delete("/sections/1");
+        expect(res.status).toBe(201);
+    });
+
+    it("regular user blocked from deleting section (403)", async () => {
+        const res = await request(buildApp(USER)).delete("/sections/1");
+        expect(res.status).toBe(403);
+    });
+
+    it("admin can rename section", async () => {
+        const res = await request(buildApp(ADMIN))
+            .put("/sections/rename/1")
+            .send({ title: "Renamed" });
+        expect(res.status).toBe(201);
+    });
+
+    it("per-game editor can rename section for their game", async () => {
+        makeGameEditor(GAME_ED.id, 1);
+        const res = await request(buildApp(GAME_ED))
+            .put("/sections/rename/1")
+            .send({ title: "Renamed" });
+        expect(res.status).toBe(201);
+    });
+
+    it("regular user blocked from renaming section (403)", async () => {
+        const res = await request(buildApp(USER))
+            .put("/sections/rename/1")
+            .send({ title: "Renamed" });
+        expect(res.status).toBe(403);
+    });
+
+    it("admin can reorder sections", async () => {
+        const res = await request(buildApp(ADMIN))
+            .put("/sections/reorder")
+            .send({ gameId: 1, sectionOrder: [{ id: 1, order: 0 }] });
+        expect(res.status).toBe(200);
+    });
+
+    it("per-game editor can reorder sections for their game", async () => {
+        makeGameEditor(GAME_ED.id, 1);
+        const res = await request(buildApp(GAME_ED))
+            .put("/sections/reorder")
+            .send({ gameId: 1, sectionOrder: [{ id: 1, order: 0 }] });
+        expect(res.status).toBe(200);
+    });
+
+    it("regular user blocked from reordering (403)", async () => {
+        const res = await request(buildApp(USER))
+            .put("/sections/reorder")
+            .send({ gameId: 1, sectionOrder: [{ id: 1, order: 0 }] });
+        expect(res.status).toBe(403);
+    });
+});


### PR DESCRIPTION
userRole added to all comment, reply, and chat message responses
canEditGame helper in auth : checks ADMIN → global EDITOR → per-game GameEditor in order
Block update/delete now allows per-game editors direct write (others still go to pending review)
Page block create/update endpoints respect the same access check
All section write operations (create, delete, rename, reorder, changePageSection) check per-game editor access

Fixed pre-existing bug: content variable was undefined in createBlockForPage pending path, would have crashed in prod ( users never hit this so far, or the editor. so all good lol )

30 new integration tests covering all roles across every affected endpoint